### PR TITLE
feature-verification PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	// Java Mail Sender
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'com.sun.mail:jakarta.mail:2.0.1'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/example/aniwhere/application/cache/RedisService.java
+++ b/src/main/java/com/example/aniwhere/application/cache/RedisService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -64,5 +65,25 @@ public class RedisService {
 
 	public void deleteOAuthToken(String email) {
 		redisTemplate.delete("OAT: " + email);
+	}
+
+	public void saveAuthCode(String toEmail, String authCode, Duration duration) {
+		redisTemplate.opsForValue().set(
+				toEmail,
+				authCode,
+				duration
+		);
+	}
+
+	public boolean hasAuthCode(String authCode) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey(authCode));
+	}
+
+	public String getAuthCode(String authCode) {
+		return redisTemplate.opsForValue().get(authCode);
+	}
+
+	public void deleteAuthCode(String authCode) {
+		redisTemplate.delete(authCode);
 	}
 }

--- a/src/main/java/com/example/aniwhere/application/user/EmailService.java
+++ b/src/main/java/com/example/aniwhere/application/user/EmailService.java
@@ -1,0 +1,36 @@
+package com.example.aniwhere.application.user;
+
+import com.example.aniwhere.global.error.ErrorCode;
+import com.example.aniwhere.global.error.exception.MailSendFailException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final JavaMailSender emailSender;
+
+	public void sendEmail(String toEmail, String title, String text) {
+
+		SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+		try {
+			emailSender.send(emailForm);
+		} catch (RuntimeException e) {
+			log.error("메일 발송에 실패했습니다. 발송 이메일:{}, 제목:{}, 내용:{}", toEmail, title, text);
+			throw new MailSendFailException("메일 발송에 실패했습니다.", ErrorCode.MAIL_SEND_FAIL);
+		}
+ 	}
+
+	private SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+		SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+		simpleMailMessage.setTo(toEmail);
+		simpleMailMessage.setSubject(title);
+		simpleMailMessage.setText("2차 인증 번호는 " + text + "입니다.");
+		return simpleMailMessage;
+	}
+}

--- a/src/main/java/com/example/aniwhere/application/user/UserService.java
+++ b/src/main/java/com/example/aniwhere/application/user/UserService.java
@@ -8,27 +8,36 @@ import com.example.aniwhere.global.error.exception.DuplicateEmailException;
 import com.example.aniwhere.global.error.ErrorCode;
 import com.example.aniwhere.global.error.exception.InvalidTokenException;
 import com.example.aniwhere.global.error.exception.NotFoundUserException;
-import com.example.aniwhere.infrastructure.jwt.JwtProperties;
 import com.example.aniwhere.infrastructure.persistence.UserRepository;
 import com.example.aniwhere.infrastructure.jwt.TokenProvider;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
+	private static final String AUTH_CODE_PREFIX = "AuthCode: ";
+
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final RedisService redisService;
-	private final JwtProperties jwtProperties;
 	private final TokenProvider tokenProvider;
+	private final EmailService emailService;
+
+	@Value("${spring.mail.auth-code-expiration-millis}")
+	private long authCodeExpirationMillis;
 
 	// 스프링 시큐리티 회원가입 시 사용되는 signup 메서드
 	public User signup(UserDTO.UserSignUpRequest request) {
@@ -94,5 +103,54 @@ public class UserService {
 	public User findById(Long userId) {
 		return userRepository.findById(userId)
 				.orElseThrow(() -> new NotFoundUserException("해당 유저는 존재하지 않는 유저입니다.", ErrorCode.NOT_FOUND_USER));
+	}
+
+	public void sendCodeToEmail(String toEmail) {
+		this.checkDuplicatedEmail(toEmail);
+		String title = "Aniwhere 이메일 2차 인증 코드 메일입니다.";
+		String code = this.createAuthCode();
+		emailService.sendEmail(toEmail, title, code);
+		redisService.saveAuthCode(AUTH_CODE_PREFIX + toEmail, code, Duration.ofMillis(this.authCodeExpirationMillis));
+	}
+
+	private String createAuthCode() {
+		int length = 6;
+		try {
+			Random random = SecureRandom.getInstanceStrong();
+			StringBuilder builder = new StringBuilder();
+			for (int i = 0; i < length; i++) {
+				builder.append(random.nextInt(10));
+			}
+			return builder.toString();
+		} catch (NoSuchAlgorithmException e) {
+			log.debug("랜덤 생성 오류");
+			throw new RuntimeException();
+		}
+	}
+
+	public UserDTO.EmailVerificationResponse verifiedCode(String email, String code) {
+		this.checkDuplicatedEmail(email);
+		String key = AUTH_CODE_PREFIX + email;
+
+		if (!redisService.hasAuthCode(key)) {
+			return new UserDTO.EmailVerificationResponse("인증 시간이 만료되었거나 인증번호가 존재하지 않습니다.", false);
+		}
+
+		String savedCode = redisService.getAuthCode(key);
+
+		if (savedCode.equals(code)) {
+			redisService.deleteAuthCode(savedCode);
+			return new UserDTO.EmailVerificationResponse("인증 성공!", true);
+		}
+
+		return new UserDTO.EmailVerificationResponse("인증번호가 일치하지 않습니다.", false);
+	}
+
+	private void checkDuplicatedEmail(String email) {
+		Optional<User> user = userRepository.findByEmail(email);
+		if (user.isPresent()) {
+			log.error("메일 중복 오류:{}", user.get());
+			throw new DuplicateEmailException(ErrorCode.EMAIL_DUPLICATION);
+		}
 	}
 }

--- a/src/main/java/com/example/aniwhere/domain/user/dto/UserDTO.java
+++ b/src/main/java/com/example/aniwhere/domain/user/dto/UserDTO.java
@@ -76,16 +76,9 @@ public class UserDTO {
 
 	@Getter
 	@Setter
-	@Builder
-	@NoArgsConstructor(access = AccessLevel.PROTECTED)
-	@AllArgsConstructor(access = AccessLevel.PROTECTED)
-	public static class KakaoUserInfo {
-		private Long id;
-		private String email;		// 이메일
-		private String nickname;	// 별명
-		private String gender;		// 성별 ex) male, female
-		private String birthday;	// 월일 ex) 0101
-		private String birthyear;	// 생년 ex) 2000
-		private String profile_image_url;	// 프로필 이미지
+	@AllArgsConstructor
+	public static class EmailVerificationResponse {
+		private String message;
+		private boolean isVerified;
 	}
 }

--- a/src/main/java/com/example/aniwhere/global/error/ErrorCode.java
+++ b/src/main/java/com/example/aniwhere/global/error/ErrorCode.java
@@ -11,14 +11,16 @@ public enum ErrorCode {
 	METHOD_NOT_ALLOWED(405, "C002", "허용되지 않는 HTTP 메서드입니다."),
 	INVALID_TYPE_VALUE(400, "C004", "유효하지 않은 타입입니다."),
 	HANDLE_ACCESS_DENIED(403, "C005", "접근 권한이 없습니다."),
-	NICKNAME_DUPLICATION(400, "C006", "중복된 메일입니다."),
-	NOT_FOUND_USER(400, "C007", "사용자를 찾을 수 없습니다."),
-	LOGIN_FAILURE(400, "C008", "이메일은 맞지만 패스워드가 일치하지 않습니다."),
-	INVALID_TOKEN(400, "C009", "유효하지 않은 토큰입니다."),
-	UNAUTHORIZED(401, "C010", "권한이 없습니다."),
+	NICKNAME_DUPLICATION(400, "C006", "중복된 닉네임입니다."),
+	EMAIL_DUPLICATION(400, "C007", "중복된 메일입니다."),
+	NOT_FOUND_USER(400, "C008", "사용자를 찾을 수 없습니다."),
+	LOGIN_FAILURE(400, "C009", "이메일은 맞지만 패스워드가 일치하지 않습니다."),
+	INVALID_TOKEN(400, "C010", "유효하지 않은 토큰입니다."),
+	UNAUTHORIZED(401, "C011", "권한이 없습니다."),
 
 	INTERNAL_SERVER_ERROR(500, "S001", "서버 측 에러입니다."),
-	NOT_FOUND_REFRESH_TOKEN(500, "S002", "리프레시 토큰을 찾을 수 없습니다.");
+	NOT_FOUND_REFRESH_TOKEN(500, "S002", "리프레시 토큰을 찾을 수 없습니다."),
+	MAIL_SEND_FAIL(500, "S003", "메일 전송에 실패했습니다.");
 
 	private int status;
 	private final String code;

--- a/src/main/java/com/example/aniwhere/global/error/exception/MailSendFailException.java
+++ b/src/main/java/com/example/aniwhere/global/error/exception/MailSendFailException.java
@@ -1,0 +1,20 @@
+package com.example.aniwhere.global.error.exception;
+
+import com.example.aniwhere.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MailSendFailException extends ServerException {
+
+	public MailSendFailException(String message, ErrorCode errorCode) {
+		super(message, errorCode);
+	}
+
+	public MailSendFailException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public MailSendFailException(String message) {
+		super(ErrorCode.MAIL_SEND_FAIL);
+	}
+}

--- a/src/main/java/com/example/aniwhere/infrastructure/config/EmailConfig.java
+++ b/src/main/java/com/example/aniwhere/infrastructure/config/EmailConfig.java
@@ -1,0 +1,66 @@
+package com.example.aniwhere.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+	@Value("${spring.mail.smtp.host}")
+	private String host;
+
+	@Value("${spring.mail.smtp.port}")
+	private int port;
+
+	@Value("${spring.mail.smtp.username}")
+	private String username;
+
+	@Value("${spring.mail.smtp.password}")
+	private String password;
+
+	@Value("${spring.mail.smtp.properties.mail.auth}")
+	private boolean auth;
+
+	@Value("${spring.mail.smtp.properties.mail.starttls.enable}")
+	private boolean starttlsEnable;
+
+	@Value("${spring.mail.smtp.properties.mail.starttls.required}")
+	private boolean starttlsRequired;
+
+	@Value("${spring.mail.smtp.properties.mail.connectiontimeout}")
+	private int connectionTimeout;
+
+	@Value("${spring.mail.smtp.properties.mail.timeout}")
+	private int timeout;
+
+	@Value("${spring.mail.smtp.properties.mail.writetimeout}")
+	private int writeTimeout;
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+		javaMailSender.setHost(host);
+		javaMailSender.setPort(port);
+		javaMailSender.setUsername(username);
+		javaMailSender.setPassword(password);
+		javaMailSender.setDefaultEncoding("UTF-8");
+		javaMailSender.setJavaMailProperties(getMailProperties());
+		return javaMailSender;
+	}
+
+	private Properties getMailProperties() {
+		Properties properties = new Properties();
+		properties.put("mail.smtp.starttls.enable", starttlsEnable);
+		properties.put("mail.smtp.starttls.required", starttlsRequired);
+		properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+		properties.put("mail.smtp.timeout", timeout);
+		properties.put("mail.smtp.writetimeout", writeTimeout);
+		properties.put("mail.smtp.auth", auth);
+		return properties;
+	}
+}

--- a/src/main/java/com/example/aniwhere/infrastructure/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/example/aniwhere/infrastructure/jwt/JwtTokenFilter.java
@@ -22,6 +22,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 	private final static List<String> WHITE_LIST = List.of(
 			"/api/auth/login",
 			"/api/auth/signup",
+			"/api/auth/email/verifications-requests",
+			"/api/auth/email/verifications",
 			"/error",
 			"/favicon.ico",
 			"/"

--- a/src/main/java/com/example/aniwhere/interfaces/rest/MailApiController.java
+++ b/src/main/java/com/example/aniwhere/interfaces/rest/MailApiController.java
@@ -1,0 +1,31 @@
+package com.example.aniwhere.interfaces.rest;
+
+import com.example.aniwhere.application.user.UserService;
+import com.example.aniwhere.domain.user.dto.UserDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MailApiController {
+
+	private final UserService userService;
+
+	@PostMapping("/auth/email/verifications-requests")
+	public ResponseEntity sendMessage(@RequestParam(name = "email") String email) {
+		userService.sendCodeToEmail(email);
+		return new ResponseEntity(HttpStatus.OK);
+	}
+
+	@GetMapping("/auth/email/verifications")
+	public ResponseEntity<UserDTO.EmailVerificationResponse> verificationEmail(@RequestParam(name = "email") String email,
+																			   @RequestParam(name = "code") String code) {
+		UserDTO.EmailVerificationResponse emailVerificationResponse = userService.verifiedCode(email, code);
+		return ResponseEntity.ok(emailVerificationResponse);
+	}
+}


### PR DESCRIPTION
### 구현된 기능

- [x] 메일 2차 인증코드 발송 기능 구현
- [x] 2차 인증코드 검증 기능 구현

### 질문 사항

* 회원가입 프로세스를 보면 보통 회원가입이 이루어지기 전 메일 인증을 먼저 처리한 후 회원가입에 들어가게 된다.
* 관심사를 분리하는 코드를 작성하기 위해 별도의 컨트롤러로 분리 후 처리하는 것이 좋을지에 대한 고민이 든다.
* 이렇게 관심사를 분리하고 프론트 측에서 API의 순서를 제어하여 인증하는 것이 가능한지 궁금하다.
* 회원가입 시 인증 코드 필드를 추가하여 발급받은 2차 인증코드와 회원가입 시 넣은 2차 인증코드가 동일한지 여부를 따져 회원가입 프로세스를 진행하는 것이 좋은지 팀원분들의 피드백을 수렴 후 코드 작업

### 관련 이슈

- closed #6 