### PR TITLE
Fix weekend anime

### DIFF
--- a/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
+++ b/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
@@ -55,8 +55,8 @@ public class AnimeController {
             description = "요일별 애니메이션을 월요일(1) ~ 일요일(7) 순으로 조회합니다."
     )
     @GetMapping("/anime/weekday")
-    public ResponseEntity<Map<Integer, List<WeekdayAnimeDTO>>> getWeekdayAnimeList(){
-        Map<Integer, List<WeekdayAnimeDTO>> animeResponse = animeService.getAnimeWeekdayList();
+    public ResponseEntity<Map<Integer, List<WeekdayAnimeDTO>>> getWeekdayAnimeList(@PathVariable Integer year, @PathVariable Integer quarter){
+        Map<Integer, List<WeekdayAnimeDTO>> animeResponse = animeService.getAnimeWeekdayList(year, quarter);
         return ResponseEntity.ok(animeResponse);
     }
 

--- a/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
+++ b/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
@@ -55,9 +55,9 @@ public class AnimeController {
             description = "요일별 애니메이션을 월요일(1) ~ 일요일(7) 순으로 조회합니다."
     )
     @GetMapping("/anime/weekday")
-    public ResponseEntity<Map<Integer, List<WeekdayAnimeDTO>>> getWeekdayAnimeList(@RequestParam(required = false) Integer year,
+    public ResponseEntity<List<AnimeGroupedByWeekdayDTO>> getWeekdayAnimeList(@RequestParam(required = false) Integer year,
                                                                                    @RequestParam(required = false) Integer quarter){
-        Map<Integer, List<WeekdayAnimeDTO>> animeResponse = animeService.getAnimeWeekdayList(year, quarter);
+        List<AnimeGroupedByWeekdayDTO> animeResponse = animeService.getAnimeWeekdayList(year, quarter);
         return ResponseEntity.ok(animeResponse);
     }
 

--- a/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
+++ b/src/main/java/com/example/aniwhere/controller/anime/controller/AnimeController.java
@@ -55,7 +55,8 @@ public class AnimeController {
             description = "요일별 애니메이션을 월요일(1) ~ 일요일(7) 순으로 조회합니다."
     )
     @GetMapping("/anime/weekday")
-    public ResponseEntity<Map<Integer, List<WeekdayAnimeDTO>>> getWeekdayAnimeList(@PathVariable Integer year, @PathVariable Integer quarter){
+    public ResponseEntity<Map<Integer, List<WeekdayAnimeDTO>>> getWeekdayAnimeList(@RequestParam(required = false) Integer year,
+                                                                                   @RequestParam(required = false) Integer quarter){
         Map<Integer, List<WeekdayAnimeDTO>> animeResponse = animeService.getAnimeWeekdayList(year, quarter);
         return ResponseEntity.ok(animeResponse);
     }

--- a/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
+++ b/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
@@ -94,8 +94,7 @@ public class AnimeDTO {
         private String title;
         private String poster;
         private String weekday;
-        private Integer airingQuarter;
-        private Integer releaseDate;
-        private Integer endDate;
+//        private LocalDate releaseDate;
+//        private LocalDate endDate;
     }
 }

--- a/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
+++ b/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
@@ -86,15 +86,21 @@ public class AnimeDTO {
         }
     }
 
+    @Builder
     @Getter
     @Setter
-    @Builder
-    public static class WeekdayAnimeDTO {//요일별 애니메이션 반환
+    public static class WeekdayAnimeDTO { // 요일별 애니메이션 DTO
         private Long animeId;
         private String title;
         private String poster;
         private String weekday;
-//        private LocalDate releaseDate;
-//        private LocalDate endDate;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    public static class AnimeGroupedByWeekdayDTO {
+        private Integer weekdayCode;
+        private List<WeekdayAnimeDTO> animes;
     }
 }

--- a/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
+++ b/src/main/java/com/example/aniwhere/domain/anime/dto/AnimeDTO.java
@@ -94,5 +94,8 @@ public class AnimeDTO {
         private String title;
         private String poster;
         private String weekday;
+        private Integer airingQuarter;
+        private Integer releaseDate;
+        private Integer endDate;
     }
 }

--- a/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepository.java
+++ b/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepository.java
@@ -1,6 +1,7 @@
 package com.example.aniwhere.repository.anime.repository;
 
 import com.example.aniwhere.domain.anime.Anime;
+import com.example.aniwhere.domain.anime.dto.AnimeDTO;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,5 +10,5 @@ import java.util.Map;
 @Repository
 public interface AnimeCustomRepository {
 
-    Map<Integer, List<Anime>> findAllGroupedByWeekday(Integer year, Integer quarter);
+    List<AnimeDTO.AnimeGroupedByWeekdayDTO> findAllGroupedByWeekday(Integer year, Integer quarter);
 }

--- a/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepository.java
+++ b/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepository.java
@@ -9,5 +9,5 @@ import java.util.Map;
 @Repository
 public interface AnimeCustomRepository {
 
-    Map<Integer, List<Anime>> findAllGroupedByWeekday();
+    Map<Integer, List<Anime>> findAllGroupedByWeekday(Integer year, Integer quarter);
 }

--- a/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/aniwhere/repository/anime/repository/AnimeCustomRepositoryImpl.java
@@ -19,9 +19,14 @@ public class AnimeCustomRepositoryImpl implements AnimeCustomRepository{
     public static final QAnime anime = new QAnime("anime");
 
     @Override
-    public Map<Integer, List<Anime>> findAllGroupedByWeekday() {
+    public Map<Integer, List<Anime>> findAllGroupedByWeekday(Integer year, Integer quarter) {
         List<Anime> allAnimes = queryFactory
                 .selectFrom(anime)
+                .where(
+                        anime.releaseDate.year().loe(year), // 출시 연도 <= 요청 연도
+                        anime.endDate.isNull().or(anime.endDate.year().goe(year)), // 종료 연도 >= 요청 연도 또는 null
+                        anime.airingQuarter.eq(quarter) // 분기 조건 일치
+                )
                 .fetch();
 
         // 요일-숫자 매핑

--- a/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
+++ b/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
@@ -113,7 +113,7 @@ public class AnimeService {
     }
 
     @Transactional(readOnly = true)
-    public Map<Integer, List<WeekdayAnimeDTO>> getAnimeWeekdayList(Integer year, Integer quarter) {
+    public List<AnimeGroupedByWeekdayDTO> getAnimeWeekdayList(Integer year, Integer quarter) {
         // 기본값 설정: 현재 연도와 분기
         if (year == null) {
             year = Year.now().getValue();
@@ -121,25 +121,8 @@ public class AnimeService {
         if (quarter == null) {
             quarter = (LocalDate.now().getMonthValue() - 1) / 3 + 1; // 현재 월 기준 분기 계산
         }
-        // 데이터 조회
-        Map<Integer, List<Anime>> groupedByWeekday = animeRepository.findAllGroupedByWeekday(year, quarter);
 
-        return groupedByWeekday.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> entry.getValue().stream()
-                                .map(anime -> WeekdayAnimeDTO.builder()
-                                        .animeId(anime.getAnimeId())
-                                        .title(anime.getTitle())
-                                        .poster(anime.getPoster())
-                                        .weekday(anime.getWeekday())
-//                                        .releaseDate(anime.getReleaseDate())
-//                                        .endDate(anime.getEndDate() != null ? anime.getEndDate() : null)
-                                        .build())
-                                .collect(Collectors.toList()),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
+        return animeRepository.findAllGroupedByWeekday(year, quarter);
     }
 }
 

--- a/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
+++ b/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
@@ -133,9 +133,8 @@ public class AnimeService {
                                         .title(anime.getTitle())
                                         .poster(anime.getPoster())
                                         .weekday(anime.getWeekday())
-                                        .airingQuarter(anime.getAiringQuarter())
-                                        .releaseDate(anime.getReleaseDate().getYear())
-                                        .endDate(anime.getEndDate().getYear())
+//                                        .releaseDate(anime.getReleaseDate())
+//                                        .endDate(anime.getEndDate() != null ? anime.getEndDate() : null)
                                         .build())
                                 .collect(Collectors.toList()),
                         (oldValue, newValue) -> oldValue,

--- a/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
+++ b/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
@@ -133,6 +133,9 @@ public class AnimeService {
                                         .title(anime.getTitle())
                                         .poster(anime.getPoster())
                                         .weekday(anime.getWeekday())
+                                        .airingQuarter(anime.getAiringQuarter())
+                                        .releaseDate(anime.getReleaseDate().getYear())
+                                        .endDate(anime.getEndDate().getYear())
                                         .build())
                                 .collect(Collectors.toList()),
                         (oldValue, newValue) -> oldValue,

--- a/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
+++ b/src/main/java/com/example/aniwhere/service/anime/service/AnimeService.java
@@ -9,11 +9,15 @@ import com.example.aniwhere.domain.category.Category;
 import com.example.aniwhere.global.error.ErrorCode;
 import com.example.aniwhere.global.error.exception.ResourceNotFoundException;
 
+import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 
+import java.time.LocalDate;
+import java.time.Year;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -109,8 +113,17 @@ public class AnimeService {
     }
 
     @Transactional(readOnly = true)
-    public Map<Integer, List<WeekdayAnimeDTO>> getAnimeWeekdayList() {
-        Map<Integer, List<Anime>> groupedByWeekday = animeRepository.findAllGroupedByWeekday();
+    public Map<Integer, List<WeekdayAnimeDTO>> getAnimeWeekdayList(Integer year, Integer quarter) {
+        // 기본값 설정: 현재 연도와 분기
+        if (year == null) {
+            year = Year.now().getValue();
+        }
+        if (quarter == null) {
+            quarter = (LocalDate.now().getMonthValue() - 1) / 3 + 1; // 현재 월 기준 분기 계산
+        }
+        // 데이터 조회
+        Map<Integer, List<Anime>> groupedByWeekday = animeRepository.findAllGroupedByWeekday(year, quarter);
+
         return groupedByWeekday.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,


### PR DESCRIPTION
* 요일별 애니메이션 수정사항

- [x] 연도와 분기 파라미터 추가
- [x] 연도와 분기 null 일때 현재 연도와 분기로 자동 세팅

* 조회 로직 추가
* 방영 기간 내에 특정 연도 및 분기가 포함되는지 확인
사실상 db 의 airing_quarter 는 방영시작분기라서 유용한 데이터는 아니라 쓰지않음
ex) 요청 : 2024 2분기
결과: 2023 1분기 ~ 2024 3분기까지 방영된 애니메이션 노출 (2024 2분기에도 방영되었기때문에)